### PR TITLE
importing os module

### DIFF
--- a/airbrake/utils/client.py
+++ b/airbrake/utils/client.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.urlresolvers import resolve
 import sys
+import os
 import urllib2
 import traceback
 from lxml import etree


### PR DESCRIPTION
running docker-compose run web manage.py syncaccounts would break from NameError: global name 'os' is not defined